### PR TITLE
[PoC] smarter CommandBus and QueryBus return types

### DIFF
--- a/src/app/features/example/actions/login.action.ts
+++ b/src/app/features/example/actions/login.action.ts
@@ -1,9 +1,10 @@
 import { Request, Response } from "express";
 import { ApiOperationPost, ApiPath } from "swagger-express-ts";
 import { celebrate, Joi } from "celebrate";
-import { CommandBus } from "@tshio/command-bus";
+
 import { LoginCommand } from "../commands/login.command";
 import { Action } from "../../../../shared/http/types";
+import { CommandBus } from "../../../../tools/command-bus";
 
 export interface LoginActionDependencies {
   commandBus: CommandBus;

--- a/src/app/features/example/actions/users.action.ts
+++ b/src/app/features/example/actions/users.action.ts
@@ -1,9 +1,9 @@
 import { Request, Response } from "express";
 import { ApiOperationGet, ApiPath } from "swagger-express-ts";
 import { celebrate, Joi } from "celebrate";
-import { QueryBus } from "@tshio/query-bus";
 import { UsersQuery } from "../queries/users";
 import { Action } from "../../../../shared/http/types";
+import { QueryBus } from "../../../../tools/query-bus";
 
 export interface UsersActionDependencies {
   queryBus: QueryBus;

--- a/src/container/command-handlers.ts
+++ b/src/container/command-handlers.ts
@@ -6,13 +6,17 @@ import LoginHandler from "../app/features/example/handlers/login.handler";
 import DeleteUserHandler from "../app/features/example/handlers/delete-user.handler";
 // HANDLERS_IMPORTS
 
+const commandHandlers = [
+  LoginHandler,
+  DeleteUserHandler,
+  // COMMAND_HANDLERS_SETUP
+];
+
+export type RegisteredCommandHandlers = typeof commandHandlers[number];
+
 export async function registerCommandHandlers(container: AwilixContainer) {
   container.register({
-    commandHandlers: asArray<any>([
-      awilix.asClass(LoginHandler),
-      awilix.asClass(DeleteUserHandler),
-      // COMMAND_HANDLERS_SETUP
-    ]),
+    commandHandlers: asArray<any>(commandHandlers.map((handler) => awilix.asClass(handler as any))),
   });
 
   return container;

--- a/src/container/query-handlers.ts
+++ b/src/container/query-handlers.ts
@@ -5,12 +5,16 @@ import { asArray } from "@tshio/awilix-resolver";
 import UsersQueryHandler from "../app/features/example/query-handlers/users.query.handler";
 // HANDLERS_IMPORTS
 
+const queryHandlers = [
+  UsersQueryHandler,
+  // QUERY_HANDLERS_SETUP
+];
+
+export type RegisteredQueryHandlers = typeof queryHandlers[number];
+
 export async function registerQueryHandlers(container: AwilixContainer) {
   container.register({
-    queryHandlers: asArray<any>([
-      awilix.asClass(UsersQueryHandler),
-      // QUERY_HANDLERS_SETUP
-    ]),
+    queryHandlers: asArray<any>(queryHandlers.map((handler) => awilix.asClass(handler))),
   });
 
   return container;

--- a/src/graphql/resolvers/index.ts
+++ b/src/graphql/resolvers/index.ts
@@ -1,5 +1,5 @@
-import { CommandBus } from "@tshio/command-bus";
-import { QueryBus } from "@tshio/query-bus";
+import { CommandBus } from "../../tools/command-bus";
+import { QueryBus } from "../../tools/query-bus";
 import { Resolvers } from "../types";
 import { usersQuery } from "../../app/features/example/graphql/queries/users.query";
 // QUERY_IMPORTS

--- a/src/tools/command-bus.ts
+++ b/src/tools/command-bus.ts
@@ -1,0 +1,12 @@
+import { CommandBus as CommandBusBase, Command } from "@tshio/command-bus";
+import { RegisteredCommandHandlers } from "../container/command-handlers";
+
+type ResultForCommand<T> = ReturnType<
+  Extract<InstanceType<RegisteredCommandHandlers>, { execute: (cmd: T) => any }>["execute"]
+>;
+
+export class CommandBus extends CommandBusBase {
+  execute<Cmd extends Command<any>>(command: Cmd) {
+    return super.execute(command) as ResultForCommand<Cmd>;
+  }
+}

--- a/src/tools/query-bus.ts
+++ b/src/tools/query-bus.ts
@@ -1,0 +1,12 @@
+import { QueryBus as QueryBusBase, Query } from "@tshio/query-bus";
+import { RegisteredQueryHandlers } from "../container/query-handlers";
+
+type ResultForQuery<T> = ReturnType<
+  Extract<InstanceType<RegisteredQueryHandlers>, { execute: (cmd: T) => any }>["execute"]
+>;
+
+export class QueryBus extends QueryBusBase {
+  execute<Q extends Query<any>>(query: Q) {
+    return super.execute(query) as ResultForQuery<Q>;
+  }
+}


### PR DESCRIPTION
I've experimented a bit and it seems that by some TypeScript tricks we are able to create smarter versions of CommandBus and QueryBus where `execute` method can infer return type basing on the command passed through argument.

I haven't tested the changes in runtime, it is just a proof of concept where you can try yourself with your IDE if type suggestions got better.