### PR TITLE
Custom ESLint rule: EventSubscriber subscription definitions rule

### DIFF
--- a/eslint.json
+++ b/eslint.json
@@ -6,7 +6,7 @@
   "env": {
     "mocha": true
   },
-  "plugins": ["prettier", "unicorn", "no-only-tests", "@typescript-eslint"],
+  "plugins": ["prettier", "unicorn", "no-only-tests", "@typescript-eslint", "tsh-custom"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "project": "./tsconfig.json"
@@ -36,7 +36,8 @@
         "case": "kebabCase"
       }
     ],
-    "curly": "error"
+    "curly": "error",
+    "tsh-custom/event-subscriptions": "error"
   },
   "overrides": [
     {

--- a/eslint/lib/event-subscriptions.js
+++ b/eslint/lib/event-subscriptions.js
@@ -1,0 +1,95 @@
+const { levenshteinDistance } = require("./utils");
+
+// Query for AST object-type elements from array from pattern like this:
+// getSubscribedEvents() {
+//   return [{...}, {...}];
+// }
+const querySubscriptionDefinitions = `MethodDefinition:has(Identifier[name="getSubscribedEvents"]) BlockStatement ReturnStatement ArrayExpression ObjectExpression`;
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    fixable: "code",
+  },
+
+  create: function (context) {
+    return {
+      [querySubscriptionDefinitions]: (node) => {
+        if (!node.properties || node.properties.length < 2) {
+          context.report(node, "Invalid subscription definition");
+          return;
+        }
+
+        // "{ name, method }" pair
+        const eventNameProperty = node.properties.find(({ key }) => key.name === "name");
+        const eventMethodProperty = node.properties.find(({ key }) => key.name === "method");
+
+        if (eventNameProperty === undefined || eventMethodProperty === undefined) {
+          context.report(node, "Invalid subscription definition");
+          return;
+        }
+
+        const eventNameExpression = eventNameProperty.value;
+        const eventMethodExpression = eventMethodProperty.value;
+
+        // Validate "{ name: ExampleEvent.eventName ... }" pattern
+        if (eventNameExpression.type !== "MemberExpression" || eventNameExpression.property.name !== "eventName") {
+          context.report(eventNameExpression, "Event name should be expression like: ExampleEvent.eventName");
+          return;
+        }
+
+        // Validate "{ ..., method: "methodLiteral"}" pattern
+        if (eventMethodExpression.type !== "Literal") {
+          context.report(eventMethodExpression, "Event method should be a literal string");
+          return;
+        }
+
+        let parent = node.parent;
+
+        // Find EventSubscriber class body
+        while (parent.type !== "ClassDeclaration") {
+          parent = parent.parent;
+        }
+
+        // Find methods of that class
+        const definedMethods = parent.body.body.filter(({ type }) => type === "MethodDefinition");
+        const definedMethodNames = definedMethods.map(({ key }) => key.name);
+
+        // Validate if method name from subscription definition matches against any methods of the EventSubscriber class
+        if (definedMethodNames.includes(eventMethodExpression.value)) {
+          return;
+        }
+
+        // Detect mistypings
+        const potentialMethodMatch = definedMethodNames.find(
+          potentialMatch => levenshteinDistance(potentialMatch, eventMethodExpression.value) <= 3
+        );
+
+        if (potentialMethodMatch !== undefined) {
+          context.report({
+            node: eventMethodExpression,
+            message: `Event handler method does not exist, but perhaps you mean "${potentialMethodMatch}" method?`,
+            fix: fixer => fixer.replaceText(eventMethodExpression, JSON.stringify(potentialMethodMatch)),
+          });
+          return;
+        }
+
+        // Propose adding handler method template if no match exists
+        const lastMethodInClass = definedMethods.slice().pop();
+        const eventClassName = eventNameExpression.object.name;
+
+        context.report({
+          node: eventMethodExpression,
+          message: "Event handler method does not exist",
+          fix: fixer => fixer.insertTextAfter(lastMethodInClass, [
+            "",
+            "",
+            `  public async ${eventMethodExpression.value}(event: ${eventClassName}) {`,
+            "    const {} = this.dependencies;",
+            "  }"
+          ].join("\n"))
+        });
+      }
+    };
+  },
+};

--- a/eslint/lib/index.js
+++ b/eslint/lib/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    "event-subscriptions": require("./event-subscriptions"),
+  },
+};

--- a/eslint/lib/utils.js
+++ b/eslint/lib/utils.js
@@ -1,0 +1,21 @@
+module.exports.levenshteinDistance = (str1 = '', str2 = '') => {
+  const track = Array(str2.length + 1).fill(null).map(() =>
+    Array(str1.length + 1).fill(null));
+  for (let i = 0; i <= str1.length; i += 1) {
+    track[0][i] = i;
+  }
+  for (let j = 0; j <= str2.length; j += 1) {
+    track[j][0] = j;
+  }
+  for (let j = 1; j <= str2.length; j += 1) {
+    for (let i = 1; i <= str1.length; i += 1) {
+      const indicator = str1[i - 1] === str2[j - 1] ? 0 : 1;
+      track[j][i] = Math.min(
+        track[j][i - 1] + 1, // deletion
+        track[j - 1][i] + 1, // insertion
+        track[j - 1][i - 1] + indicator, // substitution
+      );
+    }
+  }
+  return track[str2.length][str1.length];
+};

--- a/eslint/package.json
+++ b/eslint/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "eslint-plugin-tsh-custom",
+  "version": "0.0.1",
+  "private": "true",
+  "license": "ISC",
+  "main": "lib/index.js",
+  "directories": {
+    "lib": "lib"
+  },
+  "files": [
+    "lib"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5211,6 +5211,10 @@
         "prettier-linter-helpers": "^1.0.0"
       }
     },
+    "eslint-plugin-tsh-custom": {
+      "version": "file:eslint",
+      "dev": true
+    },
     "eslint-plugin-unicorn": {
       "version": "19.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-19.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "plop": "^2.6.0",
     "prettier": "^2.0.5",
     "supertest": "^4.0.2",
-    "typescript": "^3.8.3"
+    "typescript": "^3.8.3",
+    "eslint-plugin-tsh-custom": "file:./eslint"
   }
 }

--- a/src/app/features/example/events/user-logged-in.event.ts
+++ b/src/app/features/example/events/user-logged-in.event.ts
@@ -1,0 +1,16 @@
+import { Event } from "@tshio/event-dispatcher";
+import { LoginCommand } from "../commands/login.command";
+
+export default class UserLoggedInEvent implements Event {
+  static eventName: string = "UserLoggedIn";
+
+  public payload: LoginCommand;
+
+  get name() {
+    return UserLoggedInEvent.eventName;
+  }
+
+  public constructor(command: LoginCommand) {
+    this.payload = command;
+  }
+}

--- a/src/app/features/example/handlers/login.handler.ts
+++ b/src/app/features/example/handlers/login.handler.ts
@@ -1,6 +1,7 @@
 import { EventDispatcher } from "@tshio/event-dispatcher";
 import { CommandHandler } from "@tshio/command-bus";
 import { LOGIN_COMMAND_TYPE, LoginCommand } from "../commands/login.command";
+import UserLoggedInEvent from "../events/user-logged-in.event";
 
 export interface LoginHandlerDependencies {
   eventDispatcher: EventDispatcher;
@@ -16,10 +17,7 @@ export default class LoginCommandHandler implements CommandHandler<LoginCommand>
   }
 
   async execute(command: LoginCommand) {
-    await this.eventDispatcher.dispatch({
-      name: "UserLoggedIn",
-      payload: command,
-    });
+    await this.eventDispatcher.dispatch(new UserLoggedInEvent(command));
 
     return {
       ...command,

--- a/src/app/features/example/subscribers/email.subscriber.ts
+++ b/src/app/features/example/subscribers/email.subscriber.ts
@@ -1,5 +1,6 @@
-import { Event, EventSubscriberInterface, EventSubscribersMeta } from "@tshio/event-dispatcher";
+import { EventSubscriberInterface, EventSubscribersMeta } from "@tshio/event-dispatcher";
 import { Logger } from "@tshio/logger";
+import UserLoggedInEvent from "../events/user-logged-in.event";
 
 type EmailEventSubscriberDependencies = {
   logger: Logger;
@@ -15,14 +16,16 @@ export default class EmailEventSubscriber implements EventSubscriberInterface {
    * Register events and listeners
    * @example
    * return [
-   *  { 'name': 'TestEvent', method: 'sendEmail' }
+   *  { name: TestEvent.eventName, method: "sendEmail" }
    * ]
    */
   getSubscribedEvents(): EventSubscribersMeta[] {
-    return [{ name: "UserLoggedIn", method: "logUserLogin" }];
+    return [{ name: UserLoggedInEvent.eventName, method: "logUserLogin" }];
   }
 
-  public async logUserLogin(event: Event) {
-    this.dependencies.logger.info("User logged in", event.payload);
+  public async logUserLogin(event: UserLoggedInEvent) {
+    const { logger } = this.dependencies;
+
+    logger.info("User logged in", event.payload);
   }
 }


### PR DESCRIPTION
I've set up base for custom eslint rules in the project and added one example. 
Namely, a rule that checks if event names in subscriptions base on the existing class static prop and if handler method name is correct. It also is a good example of a rule with autofix because it can detect method name mistypings or it can even generate the template method that handles specific event.