### PR TITLE
Support for nested queries for cache query decorator

### DIFF
--- a/src/shared/cache-decorator/cache-query-decorator.ts
+++ b/src/shared/cache-decorator/cache-query-decorator.ts
@@ -4,7 +4,7 @@ function createCacheKey(target: Object, args: any[]) {
   const cacheKey = `Queries:${target.constructor.name}`;
   const arg = args[0];
   return `${cacheKey}:${Object.keys(arg)
-    .map((key) => arg[key])
+    .map((key) => `${key}=${JSON.stringify(arg[key])}`)
     .join("_")}`;
 }
 

--- a/src/tests/shared/cache-decorator.spec.ts
+++ b/src/tests/shared/cache-decorator.spec.ts
@@ -8,6 +8,11 @@ import { FlushCachedQueries } from "../../shared/cache-decorator/flush-query-cac
 
 interface CacheExampleQuery {
   id: number;
+  nestedQuery?: {
+    userDetails: {
+      name: string;
+    };
+  };
 }
 
 class CacheExampleQueryHandler implements QueryHandler<any, any> {
@@ -63,6 +68,22 @@ describe("Cache Decorator", () => {
     const secondResult = await exampleClass.execute({ id: 2 });
 
     expect(result.number).not.equal(secondResult.number);
+  });
+
+  it("return cached query result when nested query object provided", async () => {
+    const exampleClass = new CacheExampleQueryHandler();
+    const result = await exampleClass.execute({ id: 1, nestedQuery: { userDetails: { name: "foo" } } });
+    const cachedResult = await exampleClass.execute({ id: 1, nestedQuery: { userDetails: { name: "foo" } } });
+
+    expect(result.number).equal(cachedResult.number);
+  });
+
+  it("not return cached data for ghe same nested query with different params", async () => {
+    const exampleClass = new CacheExampleQueryHandler();
+    const result = await exampleClass.execute({ id: 1, nestedQuery: { userDetails: { name: "foo" } } });
+    const cachedResult = await exampleClass.execute({ id: 1, nestedQuery: { userDetails: { name: "bar" } } });
+
+    expect(result.number).not.equal(cachedResult.number);
   });
 
   it("return cached query result for cache decorator with TTL", async () => {

--- a/src/tests/shared/cache-decorator.spec.ts
+++ b/src/tests/shared/cache-decorator.spec.ts
@@ -78,7 +78,7 @@ describe("Cache Decorator", () => {
     expect(result.number).equal(cachedResult.number);
   });
 
-  it("not return cached data for ghe same nested query with different params", async () => {
+  it("not return cached data for the same nested query with different params", async () => {
     const exampleClass = new CacheExampleQueryHandler();
     const result = await exampleClass.execute({ id: 1, nestedQuery: { userDetails: { name: "foo" } } });
     const cachedResult = await exampleClass.execute({ id: 1, nestedQuery: { userDetails: { name: "bar" } } });


### PR DESCRIPTION
- fix: support for nested queries for cache query decorator
This PR fixes issue: https://github.com/TheSoftwareHouse/express-boilerplate/issues/30