### PR TITLE
fix: change event-subscriber template getSubscribedEvents method

### DIFF
--- a/plop-templates/events/event-subscriber.ts
+++ b/plop-templates/events/event-subscriber.ts
@@ -10,7 +10,7 @@ export default class {{pascalCase name}}EventSubscriber implements EventSubscrib
   public constructor(private dependencies: {{pascalCase name}}EventSubscriberDependencies) {}
 
   getSubscribedEvents(): EventSubscribersMeta[] {
-    return [{ name: {{pascalCase name}}Event.eventName, method: this.log{{pascalCase name}}.name }];
+    return [{ name: {{pascalCase name}}Event.eventName, method: "log{{pascalCase name}}" }];
   }
 
   public async log{{pascalCase name}}(event: {{pascalCase name}}Event) {


### PR DESCRIPTION
![Screenshot 2022-12-01 at 12 19 05](https://user-images.githubusercontent.com/14137191/205043345-f32a2e5a-0da6-473c-b624-d5831fb90ed3.png)
Format `this.{somemethod}.name` wasn't in line with eslint rule, so I changed the plop template to generate method name string literal