### PR TITLE
chore: bump typeorm to enable naming primary key constraints

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "swagger-ui-dist": "^4.12.0",
     "swagger-ui-express": "^4.4.0",
     "ts-pipe-compose": "^0.2.1",
-    "typeorm": "^0.3.6",
+    "typeorm": "^0.3.11",
     "typeorm-naming-strategies": "^4.1.0",
     "uuid": "^8.3.2",
     "winston": "^3.7.2",


### PR DESCRIPTION
The new version of `typeorm` allows to name primary key constraints.

![Screenshot 2023-01-04 at 14 02 31](https://user-images.githubusercontent.com/7668271/210560878-db7cb0c9-9938-41a9-82ff-5b2e916979df.png)
