### PR TITLE
Update event dispatcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@tshio/awilix-resolver": "^2.0.1",
         "@tshio/command-bus": "^1.0.4",
-        "@tshio/event-dispatcher": "^1.0.3",
+        "@tshio/event-dispatcher": "^1.1.0",
         "@tshio/logger": "^1.0.5",
         "@tshio/query-bus": "^1.0.4",
         "@tshio/security-client": "0.0.20",
@@ -3816,9 +3816,9 @@
       "integrity": "sha512-fJxAHJB5aXG5Z4oE9Q2iewy9QdqQMVbt8KhgV+tyJDLmTpK4/59T17PcB07AW6030pIR1S+Z+ggqdcg8Lrva1Q=="
     },
     "node_modules/@tshio/event-dispatcher": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tshio/event-dispatcher/-/event-dispatcher-1.0.3.tgz",
-      "integrity": "sha512-6AtHtDP3qhtnrKwXZ+byziQlXeaPq2SWYFB2JbBJ/kdOr4CgOmQvU/+he2m7TcU19tfYcBdFajj2iYinzowdVg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tshio/event-dispatcher/-/event-dispatcher-1.1.0.tgz",
+      "integrity": "sha512-fgBY54a9FyTFKn1fWj5cp75KaTP1H2aEwDo6yBqn6dRU0578RYHP9ty91WQXGo95D7ZJQKxY+29ct/TfzZCV8Q==",
       "dependencies": {
         "@tshio/logger": "^1.0.5"
       }
@@ -17348,9 +17348,9 @@
       "integrity": "sha512-fJxAHJB5aXG5Z4oE9Q2iewy9QdqQMVbt8KhgV+tyJDLmTpK4/59T17PcB07AW6030pIR1S+Z+ggqdcg8Lrva1Q=="
     },
     "@tshio/event-dispatcher": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tshio/event-dispatcher/-/event-dispatcher-1.0.3.tgz",
-      "integrity": "sha512-6AtHtDP3qhtnrKwXZ+byziQlXeaPq2SWYFB2JbBJ/kdOr4CgOmQvU/+he2m7TcU19tfYcBdFajj2iYinzowdVg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tshio/event-dispatcher/-/event-dispatcher-1.1.0.tgz",
+      "integrity": "sha512-fgBY54a9FyTFKn1fWj5cp75KaTP1H2aEwDo6yBqn6dRU0578RYHP9ty91WQXGo95D7ZJQKxY+29ct/TfzZCV8Q==",
       "requires": {
         "@tshio/logger": "^1.0.5"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@tshio/awilix-resolver": "^2.0.1",
     "@tshio/command-bus": "^1.0.4",
-    "@tshio/event-dispatcher": "^1.0.3",
+    "@tshio/event-dispatcher": "^1.1.0",
     "@tshio/logger": "^1.0.5",
     "@tshio/query-bus": "^1.0.4",
     "@tshio/security-client": "0.0.20",

--- a/src/container/common.ts
+++ b/src/container/common.ts
@@ -19,7 +19,10 @@ export async function registerCommonDependencies(appConfig: AppConfig, container
     router: asFunction(createRouter).singleton(),
     queryBus: asClass(QueryBus).classic().singleton(),
     commandBus: asClass(CommandBus).classic().singleton(),
-    eventDispatcher: asClass(EventDispatcher).classic().singleton(),
+    eventDispatcher: asClass(EventDispatcher)
+      .classic()
+      .singleton()
+      .inject(() => ({ throwOnFailure: false })),
   });
 
   return container;


### PR DESCRIPTION
Because event dispatcher package is built with a bit older target, then default parameters needs to be passed to the constructor using awilix container.