### PR TITLE
chore: set pooling as a default option for tsc watcher

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,9 @@
     "src/**/*.ts",
     "typings/*"
   ],
-  "exclude": ["node_modules", "build/**"]
+  "exclude": ["node_modules", "build/**"],
+  "watchOptions": {
+    "watchFile": "DynamicPriorityPolling",
+    "watchDirectory": "DynamicPriorityPolling"
+  }
 }


### PR DESCRIPTION
Recenty we've updated typescript to the version 4.9 that changed a way of watching files (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#file-watching-now-uses-file-system-events). Due to it, our builder (hot reload) stopped working. 

Fix: Set watcher to the pooling (as it was in the previous version)