### PR TITLE
fix: remove invalid npm option from production Dockerfile

### DIFF
--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /app
 COPY . .
 
 RUN apk add --no-cache bash curl git py-pip make
-RUN npm config set unsafe-perm true
 RUN npm i
 RUN npm run build
 #FOR SWC TRANSPILATION


### PR DESCRIPTION
npm's `unsafe-perm` option doesn't exist anymore...